### PR TITLE
Add initial retrounix64 utilities

### DIFF
--- a/retrounix64/Makefile
+++ b/retrounix64/Makefile
@@ -1,0 +1,17 @@
+CC ?= gcc
+CFLAGS = -std=c2x -O2 -nostdlib -ffreestanding -static
+
+BINARIES = usr/bin/cat usr/bin/echo
+
+all: $(BINARIES)
+
+usr/bin/cat: usr/bin/start.S usr/bin/cat.c usr/bin/sys.h
+$(CC) $(CFLAGS) usr/bin/start.S usr/bin/cat.c -o $@
+
+usr/bin/echo: usr/bin/start.S usr/bin/echo.c usr/bin/sys.h
+$(CC) $(CFLAGS) usr/bin/start.S usr/bin/echo.c -o $@
+
+clean:
+rm -f $(BINARIES)
+
+.PHONY: all clean

--- a/retrounix64/build.sh
+++ b/retrounix64/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Build RetroUnix64 utilities and prepare bootable image
+set -e
+DIR="$(dirname "$0")"
+make -C "$DIR"
+# TODO: implement bootable image packaging (requires kernel & bootloader)
+echo "Utilities built. Bootable image packaging not yet implemented." >&2

--- a/retrounix64/usr/bin/cat.c
+++ b/retrounix64/usr/bin/cat.c
@@ -1,0 +1,3 @@
+#include "sys.h"
+static void catfd(int fd){char buf[4096]; for(;;){long n=sys_read(fd,buf,sizeof(buf)); if(n<=0) break; long off=0; while(n>0){long w=sys_write(1,buf+off,n); if(w<0) return; off+=w; n-=w;}}}
+int main(int argc,char**argv){if(argc==1){catfd(0);}else{for(int i=1;i<argc;++i){long fd=sys_open(argv[i],0,0); if(fd<0){const char msg[]="cat: cannot open file\n"; sys_write(2,msg,sizeof(msg)-1); continue;} catfd(fd); sys_close(fd);}} return 0;}

--- a/retrounix64/usr/bin/echo.c
+++ b/retrounix64/usr/bin/echo.c
@@ -1,0 +1,3 @@
+#include "sys.h"
+static unsigned long strlen(const char* s){unsigned long n=0; while(s[n]) n++; return n;}
+int main(int argc,char**argv){for(int i=1;i<argc;++i){if(i>1) sys_write(1," ",1); sys_write(1,argv[i],strlen(argv[i]));} sys_write(1,"\n",1); return 0;}

--- a/retrounix64/usr/bin/start.S
+++ b/retrounix64/usr/bin/start.S
@@ -1,0 +1,8 @@
+.global _start
+_start:
+    mov (%rsp), %rdi
+    lea 8(%rsp), %rsi
+    call main
+    mov %rax, %rdi
+    mov $60, %rax
+    syscall

--- a/retrounix64/usr/bin/sys.h
+++ b/retrounix64/usr/bin/sys.h
@@ -1,0 +1,5 @@
+static inline long sys_write(int fd, const void* buf, unsigned long count){long r; __asm__ __volatile__("syscall" : "=a"(r) : "a"(1), "D"(fd), "S"(buf), "d"(count) : "rcx", "r11", "memory"); return r;}
+static inline long sys_read(int fd, void* buf, unsigned long count){long r; __asm__ __volatile__("syscall" : "=a"(r) : "a"(0), "D"(fd), "S"(buf), "d"(count) : "rcx", "r11", "memory"); return r;}
+static inline long sys_open(const char* path, int flags, int mode){long r; __asm__ __volatile__("syscall" : "=a"(r) : "a"(2), "D"(path), "S"(flags), "d"(mode) : "rcx", "r11", "memory"); return r;}
+static inline long sys_close(int fd){long r; __asm__ __volatile__("syscall" : "=a"(r) : "a"(3), "D"(fd) : "rcx", "r11", "memory"); return r;}
+static inline __attribute__((noreturn)) void sys_exit(int status){__asm__ __volatile__("syscall" : : "a"(60), "D"(status) : "rcx", "r11", "memory"); __builtin_unreachable();}


### PR DESCRIPTION
## Summary
- add retrounix64 directory with `usr/bin` utilities
- implement `cat` and `echo` in C23 style using direct syscalls
- provide start code and simple Makefile
- add a build script with a TODO for creating a bootable image

## Testing
- `gcc -std=c2x -O2 -nostdlib -ffreestanding -static retrounix64/usr/bin/start.S retrounix64/usr/bin/cat.c -o cat`
- `./cat file.txt` ✅
- `gcc -std=c2x -O2 -nostdlib -ffreestanding -static retrounix64/usr/bin/start.S retrounix64/usr/bin/echo.c -o echo`
- `./echo hello world` ✅