### PR TITLE
Add 64-bit kernel skeleton

### DIFF
--- a/retrounix64/Makefile
+++ b/retrounix64/Makefile
@@ -1,0 +1,24 @@
+NASM ?= nasm
+CC   := x86_64-elf-gcc
+LD   := x86_64-elf-ld
+OBJCOPY := x86_64-elf-objcopy
+
+CFLAGS := -std=c23 -ffreestanding -mno-red-zone -O2 -Wall -Wextra
+LDFLAGS := -T kernel/linker.ld -nostdlib
+
+all: kernel.bin
+
+boot.o: kernel/boot.s
+	$(NASM) -f elf64 $< -o $@
+
+kernel.o: kernel/main.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+kernel.bin: boot.o kernel.o
+	$(LD) $(LDFLAGS) boot.o kernel.o -o kernel.elf
+	$(OBJCOPY) -O binary kernel.elf $@
+
+clean:
+	rm -f boot.o kernel.o kernel.elf kernel.bin
+
+.PHONY: all clean

--- a/retrounix64/README.md
+++ b/retrounix64/README.md
@@ -1,0 +1,22 @@
+# Retro Unix 64 (experimental)
+
+This folder contains a very small 64-bit proof of concept kernel.  It is
+built using a cross compiler that targets the `x86_64-elf` ABI.
+
+## Building
+
+A toolchain providing `x86_64-elf-gcc` and related utilities must be
+installed and accessible from the `PATH`.
+
+```
+$ cd retrounix64
+$ make
+```
+
+The resulting `kernel.bin` can be executed with QEMU:
+
+```
+$ qemu-system-x86_64 -kernel kernel.bin -serial stdio
+```
+
+A short banner should appear on the serial console.

--- a/retrounix64/kernel/boot.s
+++ b/retrounix64/kernel/boot.s
@@ -1,0 +1,81 @@
+.section .text
+.global start
+.code16
+start:
+    cli
+    xor %ax, %ax
+    mov %ds, %ax
+    mov %ss, %ax
+    mov $0x7c00, %sp
+
+    lgdt gdt_desc
+
+    mov %cr0, %eax
+    or $1, %eax
+    mov %eax, %cr0
+    ljmp $0x08, $protected
+
+.code32
+protected:
+    mov $0x10, %ax
+    mov %ds, %ax
+    mov %ss, %ax
+    mov $0x90000, %esp
+
+    mov %cr4, %eax
+    or $0x20, %eax
+    mov %eax, %cr4
+
+    mov $pml4, %eax
+    mov %eax, %cr3
+
+    mov $0xc0000080, %ecx
+    rdmsr
+    or $0x100, %eax
+    wrmsr
+
+    mov %cr0, %eax
+    or $0x80000001, %eax
+    mov %eax, %cr0
+
+    ljmp $0x08, $longmode
+
+.code64
+longmode:
+    mov $0x10, %rax
+    mov %ds, %ax
+    mov %ss, %ax
+    mov $stack_top, %rsp
+
+    call kmain
+
+halt:
+    hlt
+    jmp halt
+
+.align 16
+gdt:
+    .quad 0
+    .quad 0x00af9a000000ffff
+    .quad 0x00af92000000ffff
+gdt_desc:
+    .word gdt_end - gdt - 1
+    .long gdt
+gdt_end:
+
+.align 4096
+pml4:
+    .quad pdpt | 3
+    .fill 511,8,0
+pdpt:
+    .quad pd | 3
+    .fill 511,8,0
+pd:
+    .quad 0x0000000000000083
+    .fill 511,8,0
+
+.section .bss
+.align 16
+stack:
+    .skip 4096
+stack_top:

--- a/retrounix64/kernel/linker.ld
+++ b/retrounix64/kernel/linker.ld
@@ -1,0 +1,9 @@
+ENTRY(start)
+SECTIONS
+{
+    . = 1M;
+    .text : { *(.text*) }
+    .rodata : { *(.rodata*) }
+    .data : { *(.data*) }
+    .bss : { *(.bss*) }
+}

--- a/retrounix64/kernel/main.c
+++ b/retrounix64/kernel/main.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+static inline void outb(uint16_t port, uint8_t val) {
+    __asm__ volatile ("outb %0,%1" : : "a"(val), "Nd"(port));
+}
+
+static void serial_init(void) {
+    outb(0x3F8 + 1, 0x00);
+    outb(0x3F8 + 3, 0x80);
+    outb(0x3F8 + 0, 0x03);
+    outb(0x3F8 + 1, 0x00);
+    outb(0x3F8 + 3, 0x03);
+    outb(0x3F8 + 2, 0xC7);
+    outb(0x3F8 + 4, 0x0B);
+}
+
+static void serial_write(const char *s) {
+    while (*s)
+        outb(0x3F8, *s++);
+}
+
+void kmain(void) {
+    serial_init();
+    serial_write("Retro Unix 64 booted\n");
+    for (;;)
+        __asm__ volatile ("hlt");
+}


### PR DESCRIPTION
## Summary
- start a new `retrounix64` directory
- implement minimal boot code to enter long mode and call `kmain`
- add a stub kernel in C printing a banner via serial
- provide linker script and cross-compiling Makefile
- document build/run steps

## Testing
- `make -C retrounix64 --dry-run`